### PR TITLE
fix: multilib only if arch = x86_64

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
     - name: set up pacman for multilib repository
       shell: bash
       run: |
-        if [ uname -m = x86_64 ]; then
+        if [ $(uname -m) == x86_64 ]; then
           sed -i "/\[multilib\]/,/Include/"'s/^#//' /etc/pacman.conf
         fi
     - name: set up pacman for target branch

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,12 @@ runs:
       run: |
         sed -i '/^\[core\]/i \Include = /etc/pacman.d/additional_repo\n' /etc/pacman.conf
         printf "${{ inputs.additional_repo }}" >/etc/pacman.d/additional_repo
+    - name: set up pacman for multilib repository
+      shell: bash
+      run: |
+        if [[ uname -m = x86_64 ]]; then
+          sed -i "/\[multilib\]/,/Include/"'s/^#//' /etc/pacman.conf
+        fi
     - name: set up pacman for target branch
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
     - name: set up pacman for multilib repository
       shell: bash
       run: |
-        if [[ uname -m = x86_64 ]]; then
+        if [ uname -m = x86_64 ]; then
           sed -i "/\[multilib\]/,/Include/"'s/^#//' /etc/pacman.conf
         fi
     - name: set up pacman for target branch

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,8 @@ runs:
       run: |
         if [ $(uname -m) == x86_64 ]; then
           sed -i "/\[multilib\]/,/Include/"'s/^#//' /etc/pacman.conf
+        else
+          exit 0
         fi
     - name: set up pacman for target branch
       shell: bash


### PR DESCRIPTION
@boredland I hope this is the final solution for multilib repo as without it lib32 packages are not possible to build.