### PR TITLE
ci: use GitHub-hosted aarch64 runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         pkgbuild: ["PKGBUILD.any", "PKGBUILD.multi"]
         branch: [stable, testing, unstable]
-        runs-on: [buildjet-4vcpu-ubuntu-2204-arm, ubuntu-latest]
+        runs-on: [ubuntu-24.04-arm, ubuntu-latest]
     runs-on: ${{ matrix.runs-on }}
     container:
       image: docker://manjarolinux/build:latest


### PR DESCRIPTION
## Summary
- Switches the test matrix from `buildjet-4vcpu-ubuntu-2204-arm` to `ubuntu-24.04-arm`, GitHub's natively hosted ARM64 runner.
- GitHub-hosted ARM64 runners are now generally available for public repositories, so the external BuildJet dependency is no longer required for aarch64 builds.

## Test plan
- [ ] CI runs green on both `ubuntu-24.04-arm` and `ubuntu-latest` across the existing PKGBUILD × branch matrix